### PR TITLE
Convert AniDb image providers

### DIFF
--- a/MediaBrowser.Plugins.Anime.Tests/MediaBrowser.Plugins.Anime.Tests.csproj
+++ b/MediaBrowser.Plugins.Anime.Tests/MediaBrowser.Plugins.Anime.Tests.csproj
@@ -30,20 +30,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MediaBrowser.Common, Version=3.0.5111.24450, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MediaBrowser.Common.3.0.293\lib\net45\MediaBrowser.Common.dll</HintPath>
+    <Reference Include="MediaBrowser.Common">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.329\lib\net45\MediaBrowser.Common.dll</HintPath>
     </Reference>
     <Reference Include="MediaBrowser.Common.Implementations">
       <HintPath>.\MediaBrowser.Common.Implementations.dll</HintPath>
     </Reference>
-    <Reference Include="MediaBrowser.Controller, Version=3.0.5111.24450, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MediaBrowser.Server.Core.3.0.293\lib\net45\MediaBrowser.Controller.dll</HintPath>
+    <Reference Include="MediaBrowser.Controller">
+      <HintPath>..\packages\MediaBrowser.Server.Core.3.0.329\lib\net45\MediaBrowser.Controller.dll</HintPath>
     </Reference>
-    <Reference Include="MediaBrowser.Model, Version=3.0.5111.24450, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MediaBrowser.Common.3.0.293\lib\net45\MediaBrowser.Model.dll</HintPath>
+    <Reference Include="MediaBrowser.Model">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.329\lib\net45\MediaBrowser.Model.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.2.1312.1622, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/MediaBrowser.Plugins.Anime.Tests/packages.config
+++ b/MediaBrowser.Plugins.Anime.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MediaBrowser.Common" version="3.0.293" targetFramework="net45" />
-  <package id="MediaBrowser.Server.Core" version="3.0.293" targetFramework="net45" />
+  <package id="MediaBrowser.Common" version="3.0.329" targetFramework="net45" />
+  <package id="MediaBrowser.Server.Core" version="3.0.329" targetFramework="net45" />
   <package id="Moq" version="4.2.1312.1622" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/MediaBrowser.Plugins.Anime/MediaBrowser.Plugins.Anime.csproj
+++ b/MediaBrowser.Plugins.Anime/MediaBrowser.Plugins.Anime.csproj
@@ -30,17 +30,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MediaBrowser.Common, Version=3.0.5111.24450, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MediaBrowser.Common.3.0.293\lib\net45\MediaBrowser.Common.dll</HintPath>
+    <Reference Include="MediaBrowser.Common">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.329\lib\net45\MediaBrowser.Common.dll</HintPath>
     </Reference>
-    <Reference Include="MediaBrowser.Controller, Version=3.0.5111.24450, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MediaBrowser.Server.Core.3.0.293\lib\net45\MediaBrowser.Controller.dll</HintPath>
+    <Reference Include="MediaBrowser.Controller">
+      <HintPath>..\packages\MediaBrowser.Server.Core.3.0.329\lib\net45\MediaBrowser.Controller.dll</HintPath>
     </Reference>
-    <Reference Include="MediaBrowser.Model, Version=3.0.5111.24450, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MediaBrowser.Common.3.0.293\lib\net45\MediaBrowser.Model.dll</HintPath>
+    <Reference Include="MediaBrowser.Model">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.329\lib\net45\MediaBrowser.Model.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq">
       <HintPath>..\packages\morelinq.1.0.16006\lib\net35\MoreLinq.dll</HintPath>
@@ -95,7 +92,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetPath)" "%25MediaBrowserData%25\plugins\" /y</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MediaBrowser.Plugins.Anime/Providers/AnimeSeriesProvider.cs
+++ b/MediaBrowser.Plugins.Anime/Providers/AnimeSeriesProvider.cs
@@ -100,14 +100,14 @@ namespace MediaBrowser.Plugins.Anime.Providers
 
             if (!series.DontFetchMeta)
             {
-                if (force || PluginConfiguration.Instance().AllowAutomaticMetadataUpdates || !item.ResolveArgs.ContainsMetaFileByName("series.xml"))
-                {
-                    SeriesInfo initialSeriesInfo = SeriesInfo.FromSeries(series);
-                    initialSeriesInfo.ExternalProviders[ProviderNames.AniDb] = await FindAniDbId(initialSeriesInfo, GetFolderName(series), cancellationToken).ConfigureAwait(false);
+                //if (force || PluginConfiguration.Instance().AllowAutomaticMetadataUpdates || !item.ResolveArgs.ContainsMetaFileByName("series.xml"))
+                //{
+                //    SeriesInfo initialSeriesInfo = SeriesInfo.FromSeries(series);
+                //    initialSeriesInfo.ExternalProviders[ProviderNames.AniDb] = await FindAniDbId(initialSeriesInfo, GetFolderName(series), cancellationToken).ConfigureAwait(false);
 
-                    SeriesInfo merged = await FindSeriesInfo(initialSeriesInfo, item.GetPreferredMetadataLanguage(), cancellationToken);
-                    merged.Set(series);
-                }
+                //    SeriesInfo merged = await FindSeriesInfo(initialSeriesInfo, item.GetPreferredMetadataLanguage(), cancellationToken);
+                //    merged.Set(series);
+                //}
             }
 
             SetLastRefreshed(item, DateTime.UtcNow, providerInfo);

--- a/MediaBrowser.Plugins.Anime/packages.config
+++ b/MediaBrowser.Plugins.Anime/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MediaBrowser.Common" version="3.0.293" targetFramework="net45" />
-  <package id="MediaBrowser.Server.Core" version="3.0.293" targetFramework="net45" />
+  <package id="MediaBrowser.Common" version="3.0.329" targetFramework="net45" />
+  <package id="MediaBrowser.Server.Core" version="3.0.329" targetFramework="net45" />
   <package id="morelinq" version="1.0.16006" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Convert AniDb image providers. It makes use of the existing IndexNumber field to track the series index.

The provider will not have the ability to overwrite existing images, so it will have to be user-prioritized ahead of the core ones. If you really want to overwrite, you can always do a custom metadata provider later, but that won't be user-configurable.
